### PR TITLE
Bug fix: clicking nonexistent line number

### DIFF
--- a/app/text_buffer.py
+++ b/app/text_buffer.py
@@ -1310,18 +1310,17 @@ class BackingTextBuffer(Mutator):
     self.doSelectionMode(app.selectable.kSelectionWord)
 
   def selectLineAt(self, row):
-    if 1:
-      self.cursorMove(row - self.penRow, 0)
-      self.redo()
-      self.selectionLine()
-      self.cursorMoveAndMark(*self.extendSelection())
-      self.redo()
-    else:
-      # TODO(dschuyler): reverted to above to fix line selection in the line
-      # numbers column. To be investigated further.
-      if row >= len(self.lines):
-        return
-      self.selectText(row, 0, 0, app.selectable.kSelectionLine)
+    if row < len(self.lines):
+      if 1:
+        self.cursorMove(row - self.penRow, 0)
+        self.redo()
+        self.selectionLine()
+        self.cursorMoveAndMark(*self.extendSelection())
+        self.redo()
+      else:
+        # TODO(dschuyler): reverted to above to fix line selection in the line
+        # numbers column. To be investigated further.
+        self.selectText(row, 0, 0, app.selectable.kSelectionLine)
 
   def selectWordAt(self, row, col):
     """row and col may be from a mouse click and may not actually land in the

--- a/app/window.py
+++ b/app/window.py
@@ -409,9 +409,7 @@ class LineNumbers(StaticWindow):
   def mouseRelease(self, paneRow, paneCol, shift, ctrl, alt):
     app.log.info(paneRow, paneCol, shift)
     tb = self.host.textBuffer
-    selectedLine = self.host.scrollRow + paneRow
-    if selectedLine < len(tb.lines):
-      tb.selectLineAt(selectedLine)
+    tb.selectLineAt(self.host.scrollRow + paneRow)
 
   def mouseTripleClick(self, paneRow, paneCol, shift, ctrl, alt):
     pass

--- a/app/window.py
+++ b/app/window.py
@@ -409,7 +409,9 @@ class LineNumbers(StaticWindow):
   def mouseRelease(self, paneRow, paneCol, shift, ctrl, alt):
     app.log.info(paneRow, paneCol, shift)
     tb = self.host.textBuffer
-    tb.selectLineAt(self.host.scrollRow + paneRow)
+    selectedLine = self.host.scrollRow + paneRow
+    if selectedLine < len(tb.lines):
+      tb.selectLineAt(selectedLine)
 
   def mouseTripleClick(self, paneRow, paneCol, shift, ctrl, alt):
     pass


### PR DESCRIPTION
Fixed bug where the program would error out if the user selected a section in the LineNumber window when there are not that many lines in the text buffer. ie: You select what would be line 5 when there are only 2 lines.