### PR TITLE
Fixed cursor position when starting up a saved file

### DIFF
--- a/app/text_buffer.py
+++ b/app/text_buffer.py
@@ -951,7 +951,7 @@ class BackingTextBuffer(Mutator):
 
   def selectText(self, row, col, length, mode):
     row = max(0, min(row, len(self.lines)-1))
-    col = max(0, min(col, len(self.lines[row])-1))
+    col = max(0, min(col, len(self.lines[row])))
     scrollRow = self.view.scrollRow
     scrollCol = self.view.scrollCol
     maxRow, maxCol = self.view.cursorWindow.getmaxyx()


### PR DESCRIPTION
Don't know if there was a reason for this cap, but it doesn't seem to break or affect anything if I change it like this. This fixes the cursor position issue described in #13.