### PR TITLE
Pasting Error Fix

### DIFF
--- a/third_party/pyperclip/clipboards.py
+++ b/third_party/pyperclip/clipboards.py
@@ -1,3 +1,4 @@
+import os
 import sys
 import subprocess
 from .exceptions import PyperclipException
@@ -68,8 +69,10 @@ def init_xclip_clipboard():
         p.communicate(input=text.encode('utf-8'))
 
     def paste_xclip():
-        p = subprocess.Popen(['xclip', '-selection', 'c', '-o'],
-                             stdout=subprocess.PIPE, close_fds=True)
+        with open(os.devnull, 'w') as devnull:
+            p = subprocess.Popen(['xclip', '-selection', 'c', '-o'],
+                                 stdout=subprocess.PIPE, stderr=devnull,
+                                 close_fds=True)
         stdout, stderr = p.communicate()
         return stdout.decode('utf-8')
 


### PR DESCRIPTION
An error would print by a subprocess function when you try to paste a non-printable object from the clipboard like an image. This redirects the error message to null. I didn't want to modify this third party library directly, but it didn't seem like it would let me redirect this output in app.clipboard.paste() or text_buffer.editPaste() 