### PR TITLE
Fixed bug that occurred when default 'python' refers to python3

### DIFF
--- a/ci.py
+++ b/ci.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # TODO(dschuyler): !/usr/bin/python -O
 
 # Copyright 2016 Google Inc.

--- a/ci.py
+++ b/ci.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/python2.7
 # TODO(dschuyler): !/usr/bin/python -O
 
 # Copyright 2016 Google Inc.


### PR DESCRIPTION
Changed the she-bang so that it should now refer to python 2 (since we don't have python3 support as of now)