### PR TITLE
updated install directory to use subdirectory of "ci_edit"

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -40,7 +40,7 @@ fi
 # grab current directory name to use as subdirectory for the installed app
 APP_DIR=$(basename "$SRC_PATH")
 # path for sym link to executable ci.py
-IN_PATH="/usr/local/bin"
+BIN_PATH="/usr/local/bin"
 # location of install directory
 APP_PATH="/opt"
 # full install directory

--- a/install.sh
+++ b/install.sh
@@ -29,24 +29,31 @@ if [ "$(id -u)" != "0" ]; then
     [[ "$0" = "$BASH_SOURCE" ]] && exit 1 || return 1
 fi
 
-# Split path to this install script into an array.
-IFS='/' SRC_PATH=($0)
-# Remove this file name.
-unset SRC_PATH[-1]
-# Grab the directory name.
-APP_DIR="${SRC_PATH[-1]}"
-# Joint path back together.
-SRC_PATH="${SRC_PATH[*]}"
+# source path to find current directory and to copy application to /opt/
+SRC_PATH=$(dirname "$0") # path from which install was executed
+SRC_PATH=$(cd "$SRC_PATH" && pwd)  # absolute path
+if [ -z "$SRC_PATH" ]; then
+    # exit if for some reason, the path is empty string
+    [[ "$0" = "$BASH_SOURCE" ]] && exit 1 || return 1
+fi
+
+# grab current directory name to use as subdirectory for the installed app
+APP_DIR=$(basename "$SRC_PATH")
+# path for sym link to executable ci.py
 BIN_PATH="/usr/local/bin"
+# location of install directory
 APP_PATH="/opt"
+# full install directory
 INSTALL_DIR="${APP_PATH}/${APP_DIR}"
 
 echo "* *********************************************************** *"
 echo "*                                                             *"
 echo "*   installation steps:                                       *"
 echo "*                                                             *"
-echo "*   (1) copies (or updates) ci_edit directory to the path:    *"
-echo "*       '$INSTALL_DIR'"
+echo "*   (1) copies (or updates) '$APP_DIR' directory to the path: *"
+echo "*       '$INSTALL_DIR'                                        *"
+echo "*       NOTE: update will use the command:                    *"
+echo "*       $ rm -rf $INSTALL_DIR                                 *"
 echo "*                                                             *"
 echo "*   (2) creates (or updates) the execution command:           *"
 echo "*       (a) this will be a sym link to the install directory  *"
@@ -82,15 +89,19 @@ else
 fi
 
 # Go over board to avoid "rm -rf /"; e.g. APP_PATH is set above, testing anyway.
-if [[ -z "$APP_PATH" || -z "${APP_DIR}" || "$INSTALL_DIR" -eq "/" ]]; then
+if [[ -z "$APP_PATH" || -z "${APP_DIR}" || "$INSTALL_DIR" == "/" ]]; then
   echo "Something is incorrect about the install directory. Exiting."
   exit -1
 fi
 # Yes, this is redundant with the above. User safety is top priority.
-if [[ -n "$APP_PATH" && -n "${APP_DIR}" && "$INSTALL_DIR" -ne "/" ]]; then
-  rm -rf "$INSTALL_DIR"
+# Only continues to delete if directory exists and is not root '/'
+if [[ -n "$APP_PATH" && -n "${APP_DIR}" && "$INSTALL_DIR" != "/" ]]; then
+    rm -rf "$INSTALL_DIR"
 fi
 
+# creates the directory if not already existing /opt/
+mkdir -p /opt/
+# Copies Source to /opt/$INSTALL_DIR
 cp -Rv "$SRC_PATH" "$INSTALL_DIR"
 # Make installed directories usable by all users.
 find "$INSTALL_DIR" -type d -exec chmod +rx {} \;

--- a/readme.md
+++ b/readme.md
@@ -35,28 +35,30 @@ extras. Those fancy extras stay out of your way until you want them.
 
 ### Installation (Linux / Mac OS)
 
-* Change directory `cd` to the downloaded directory (or local repository):
-  `ci_edit`. (Or use the path to "install.sh" in the command below).
+* Execute the install script with root privileges.  Either change directory
+  `cd` to the downloaded directory (or local repository): `ci_edit`, or use
+  the path to the installation file (i.e. `./[PATH_TO_FILE]/install.sh`).
 
 ```
 $ sudo ./install.sh
 ```
 
 * **Note:** This script creates a copy of the repository in the directory
-  `/opt/ci_edit`; the **update**, overwrites that copy.  Then a symbolic
-  link is created in the directory `/usr/local/bin`, which is generally
+  `/opt/ci_edit/`; the **update**, overwrites that copy.  Then a symbolic
+  link is created in the directory `/usr/local/bin/`, which is generally
   designated for user programs not managed by the distribution package manager
 
 ### Usage
 
 * This command opens the text editor from any directory.  The execution command
-  for the editor can be specified by user choice
+  for the editor can be specified by user choice during installation or
+  manually.
 
 ```
 $ we
 ```
 
-* to edit a file by name
+* To edit a file (such as README.md) by name:
 
 ```
 $ we README.md


### PR DESCRIPTION
@dschuyler, I like the changes you made to safe guard the `rm -rf` command, and all the comments you added.  Also, nice work putting in the `$INSTALL_DIR` in the setup instructions...  I wonder, did you intend to make the install script copy all contents of `ci_edit` to directory `/opt/./`?  When the install script is run like `./install.sh`, `$0` is = to`./install.sh` and since this is a relative path, the method of creating an array of this path ends up making the install directory = `/opt/./`, which becomes a bit redundant and also doesn't organize the package neatly into it's own sub directory (**EDIT**: also this messes with the editors commands -> i.e. ctrl q to quit, no longer functions in the editor -- I don't know why?)...  Originally, it was setup to copy the application to the directory: `/opt/ci_edit/`, which is a bit cleaner as ci_edit would have it's own separate directory for it's package.  Generally `/opt/` is supposed to have the packages in their own subdirectory.

In this PR:

* The assurance that the name of the working directory (and install subdirectory) is not `'./'` by finding the full path of the current directory, `$(basename $(pwd))` (i.e. `$ basename $(pwd)`), then this ensures that the install dir is it's own subdirectory of `/opt/`
* updated documentation and a warning of the usage of `rm -rf`
* I tested in both Linux and Mac Terminal and functions great.
* By the way, Your safeguard check did not continue with the install in my mac terminal when the install directory was `'./'`, so nice work with that.
* Also incorporated PR from @Crabime #52, to ensure that the directory `/opt/` does exist by creating it if it doesn't (`mkdir -p /opt/`).