### PR TITLE
Made all labels have the message_line color

### DIFF
--- a/app/window.py
+++ b/app/window.py
@@ -280,7 +280,7 @@ class LabeledLine(Window):
 
   def refresh(self):
     self.leftColumn.addStr(0, 0, self.label,
-        app.prefs.color['default'])
+        app.color.get('message_line'))
     Window.refresh(self)
 
   def reshape(self, rows, cols, top, left):


### PR DESCRIPTION
Now all messages that appear in LabeledLine will have the yellowish color. This color differs from terminal to terminal but is all sort of yellow (from what I found). I could use the default color (black text on white background), but this seems to catch the eye more so the user can easily see that some text just appeared on the screen. Resolves #54 