### PR TITLE
New color for status line

### DIFF
--- a/app/window.py
+++ b/app/window.py
@@ -280,7 +280,7 @@ class LabeledLine(Window):
 
   def refresh(self):
     self.leftColumn.addStr(0, 0, self.label,
-        app.color.get('message_line'))
+        app.color.get('keyword'))
     Window.refresh(self)
 
   def reshape(self, rows, cols, top, left):


### PR DESCRIPTION
I figured a bright blue would work. It seems to be somewhat more consistent throughout the terminals. See if this is true for you as well. I used the keyword color, since it's currently not being used by much. If we end up using this color more in the text, we may have to change this status color since it won't be the only blue anymore and won't pop out as much.

I could always change the background part of it too and make it unique, but I think that's less aesthetically pleasing than if the background matched its surroundings

![image](https://user-images.githubusercontent.com/19481525/29633331-cd7ece88-87fa-11e7-8d49-7aca68c60b6a.png)
