### PR TITLE
Added a --clearHistory flag to clear all existing user edit history.

### DIFF
--- a/app/ci_program.py
+++ b/app/ci_program.py
@@ -521,6 +521,9 @@ class CiProgram:
         elif i == '--version':
           userMessage(app.help.docs['version'])
           self.quitNow()
+        elif i == '--clearHistory':
+          app.history.clearUserHistory()
+          self.quitNow()
         elif i.startswith('--'):
           userMessage("unknown command line argument", i)
           self.quitNow()

--- a/app/ci_program.py
+++ b/app/ci_program.py
@@ -592,7 +592,6 @@ class CiProgram:
       self.dirPrefs = os.path.join(homePath, 'prefs')
       if not os.path.isdir(self.dirPrefs):
         os.makedirs(self.dirPrefs)
-      app.history.path = os.path.join(homePath, app.history.path)
     except Exception, e:
       app.log.error('exception in makeHomeDirs')
 


### PR DESCRIPTION
Sometimes want to do this when updating a new version in case implementation of how history is stored changes and files go bad. Mostly intended to be used to debug things. This command removes ALL file history. The log might throw an exception if you try to use this flag twice in a row, because it is trying to delete a file that is only created when you save a file with the program. This exception can be safely ignored, since the program should quit after running with this flag anyway.