### PR TITLE
Fix pasting from breaking the redo chain

### DIFF
--- a/app/ci_program.py
+++ b/app/ci_program.py
@@ -521,6 +521,9 @@ class CiProgram:
         elif i == '--version':
           userMessage(app.help.docs['version'])
           self.quitNow()
+        elif i == '--clearHistory':
+          app.history.clearUserHistory()
+          self.quitNow()
         elif i.startswith('--'):
           userMessage("unknown command line argument", i)
           self.quitNow()

--- a/app/ci_program.py
+++ b/app/ci_program.py
@@ -592,7 +592,6 @@ class CiProgram:
       self.dirPrefs = os.path.join(homePath, 'prefs')
       if not os.path.isdir(self.dirPrefs):
         os.makedirs(self.dirPrefs)
-      app.history.path = os.path.join(homePath, app.history.path)
     except Exception, e:
       app.log.error('exception in makeHomeDirs')
 

--- a/app/ci_program.py
+++ b/app/ci_program.py
@@ -21,7 +21,6 @@ if os.getenv('CI_EDIT_USE_FAKE_CURSES'):
 
 
 import app.background
-import app.bookmarks
 import app.curses_util
 import app.help
 import app.history

--- a/app/default_prefs.py
+++ b/app/default_prefs.py
@@ -115,7 +115,6 @@ prefs = {
     'c_string2': stringColorIndex,
     'debug_window': defaultColorIndex,
     'regex_string': stringColorIndex,
-    'regex_string2': stringColorIndex,
     'doc_block_comment': commentColorIndex,
     'html_block_comment': commentColorIndex,
     'html_element': keywordsColorIndex,
@@ -421,7 +420,7 @@ prefs = {
       ],
       'contains': [
         'c_string1', 'c_string2', 'doc_block_comment', 'cpp_block_comment',
-        'cpp_line_comment', 'regex_string', 'regex_string2',
+        'cpp_line_comment', 'regex_string',
       ],
     },
     'keyword': {
@@ -515,17 +514,7 @@ prefs = {
       'end': '"',
     },
     'regex_string': {
-      #'begin': r"(?<=[\n=:;([{,])(?:\s*)/(?![/*])",
-      'begin': r"(?<=[\n=:;([{,])/(?![/*])",
-      'end': "/",
-      'escaped': r'\\.',
-      'indent': '  ',
-      'special': __special_string_escapes + [r"\\/"],
-      'single_line': True,
-    },
-    'regex_string2': {
-      #'begin': r"(?<=[\n=:;([{,])(?:\s*)/(?![/*])",
-      'begin': r"(?<=[\n=:;([{,]\s)/(?![/*])",
+      'begin': r"(?<=[\n=:;([{,])(?:\s*)/(?![/*])",
       'end': "/",
       'escaped': r'\\.',
       'indent': '  ',

--- a/app/parser.py
+++ b/app/parser.py
@@ -34,7 +34,7 @@ class ParserNode:
     self.begin = None  # Offset from start of file.
 
   def debugLog(self, out, indent, data):
-    out('%sParserNode %16s prior %4s %4d %s' % (indent,
+    out('%sParserNode %26s prior %4s %4d %s' % (indent,
         self.grammar.get('name', 'None'),
         self.prior, self.begin, repr(data[self.begin:self.begin+15])[1:-1]))
 
@@ -190,11 +190,14 @@ class Parser:
         child.begin = cursor + reg[1]
         child.prior = self.parserNodes[self.parserNodes[-1].prior].prior
         cursor = child.begin
-        if subdata[reg[0]:reg[1]] == '\n':
+        if subdata[reg[1] - 1:reg[1]] == '\n':
           # This 'end' ends with a new line.
           self.rows.append(len(self.parserNodes))
       elif index < newGrammarIndexLimit:
         # A new grammar within this grammar (a 'contains').
+        if subdata[reg[0]:reg[0] + 1] == '\n':
+          # This 'begin' begins with a new line.
+          self.rows.append(len(self.parserNodes))
         child.grammar = self.parserNodes[-1].grammar.get(
             'matchGrammars', [])[index]
         child.begin = cursor + reg[0]


### PR DESCRIPTION
I think when you removed that line `len(self.redoChain) != self.redoIndex`, it might've caused this bug. The bug was caused because pasting consisted of an `insertLines` part and then a `cursorMove` part. However, I think removing that line caused the `cursorMove` part to become a `tempChange`. tempChange is not saved/restored in user history, so that sometimes caused an issue when reopening the file.

I combined the `insertLines` and the `cursorMove` part into one `paste` change, so this should fix the bug.
There probably could have been other fixes like saving tempChange, but that would mean trivial actions would also get saved and I don't know if that would be useful or annoying. We could also probably redo the logic and keep the paste change as 2 separate parts, but I thought this would be cleaner.