### PR TITLE
Allow reversing scroll direction

### DIFF
--- a/app/actions.py
+++ b/app/actions.py
@@ -1291,7 +1291,10 @@ class Actions(app.mutator.Mutator):
   def mouseWheelDown(self, shift, ctrl, alt):
     if not shift:
       self.selectionNone()
-    self.scrollUp()
+    if app.prefs.editor['naturalScrollDirection']:
+      self.scrollUp()
+    else:
+      self.scrollDown()
 
   def scrollUp(self):
     if self.view.scrollRow == 0:
@@ -1309,7 +1312,10 @@ class Actions(app.mutator.Mutator):
   def mouseWheelUp(self, shift, ctrl, alt):
     if not shift:
       self.selectionNone()
-    self.scrollDown()
+    if app.prefs.editor['naturalScrollDirection']:
+      self.scrollDown()
+    else:
+      self.scrollUp()
 
   def scrollDown(self):
     maxRow, maxCol = self.view.rows, self.view.cols

--- a/app/default_prefs.py
+++ b/app/default_prefs.py
@@ -199,6 +199,7 @@ prefs = {
   },
   'editor': {
     'captiveCursor': False,
+    'naturalScrollDirection': True,
     'colorScheme': 'default',
     'findIgnoreCase': True,
     'indentation': '  ',


### PR DESCRIPTION
As proposed in #58 , this pr adds an option for user to reverse scroll direction. I used Apple's naming of the current direction mode in OS X - natural direction.

P.S.
Why do we want to unselect things when scrolling down/up using mouse wheel if shift is not held? For other GUI editors, I believe the behavior is to keep the original selection; for console editor like vim, the behavior is to scroll to expand/narrow the selection.

I think we can keep the selection if shift is not pressed like other gui editors and move the selection when shift is pressed like other console editors.