### PR TITLE
Bug fix/consistent indenting

### DIFF
--- a/app/actions.py
+++ b/app/actions.py
@@ -260,12 +260,12 @@ class Actions(app.mutator.Mutator):
     self.redo()
     if 1:  # TODO(dschuyler): if indent on CR
       line = self.lines[self.penRow - 1]
-      commonIndent = 2
+      commonIndent = len(app.prefs.editor['indentation'])
       indent = 0
       while indent < len(line) and line[indent] == ' ':
         indent += 1
       if len(line):
-        if line[-1] in [':', '[', '{']:
+        if line.rstrip()[-1] in [':', '[', '{']:
           indent += commonIndent
         # Good idea or bad idea?
         #elif indent >= 2 and line.lstrip()[:6] == 'return':

--- a/app/ci_program.py
+++ b/app/ci_program.py
@@ -521,6 +521,9 @@ class CiProgram:
         elif i == '--version':
           userMessage(app.help.docs['version'])
           self.quitNow()
+        elif i == '--clearHistory':
+          app.history.clearUserHistory()
+          self.quitNow()
         elif i.startswith('--'):
           userMessage("unknown command line argument", i)
           self.quitNow()

--- a/app/ci_program.py
+++ b/app/ci_program.py
@@ -592,7 +592,6 @@ class CiProgram:
       self.dirPrefs = os.path.join(homePath, 'prefs')
       if not os.path.isdir(self.dirPrefs):
         os.makedirs(self.dirPrefs)
-      app.history.path = os.path.join(homePath, app.history.path)
     except Exception, e:
       app.log.error('exception in makeHomeDirs')
 

--- a/app/ci_program.py
+++ b/app/ci_program.py
@@ -21,7 +21,6 @@ if os.getenv('CI_EDIT_USE_FAKE_CURSES'):
 
 
 import app.background
-import app.bookmarks
 import app.curses_util
 import app.help
 import app.history


### PR DESCRIPTION
Resolves #96 and also auto indents even if there is trailing whitespace after a **:**, **{**, or **(**