### PR TITLE
Fixed test runner

### DIFF
--- a/unit_tests.py
+++ b/unit_tests.py
@@ -63,7 +63,7 @@ tests = {
 
 def runTests(tests, stopOnFailure=False):
   """Run through the list of tests."""
-  for test in tests:
+  for test in tests.values():
     suite = unittest.TestLoader().loadTestsFromTestCase(test)
     result = unittest.TextTestRunner(verbosity = 2).run(suite)
     if stopOnFailure and (result.failures or result.errors):
@@ -72,4 +72,4 @@ def runTests(tests, stopOnFailure=False):
 
 if __name__ == '__main__':
   app.log.info("starting unit tests")
-  app.log.wrapper(runTests)
+  app.log.wrapper(lambda: runTests(tests))


### PR DESCRIPTION
The commit "1d628d76" seemed to have changed the `runTests` function, but didn't change how calls to it were made. This should fix it. 

One question though: do you know why when I just run `python unit_tests.py`, it doesn't run the performance test, but when I put a run the same thing with a `import pdb; pdb.set_trace` break statement, and simply hit continue, it runs the performance tests?