### PR TITLE
Avoid unnecessay function call overhead and bare exceptions

### DIFF
--- a/app/actions.py
+++ b/app/actions.py
@@ -17,8 +17,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 try:
-  unicode('')
-except:
+  unicode
+except NameError:
   unicode = str
   unichr = chr
 

--- a/app/debug_window.py
+++ b/app/debug_window.py
@@ -16,8 +16,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 try:
-  unicode('')
-except:
+  unicode
+except NameError:
   unicode = str
   unichr = chr
 

--- a/app/editor.py
+++ b/app/editor.py
@@ -18,8 +18,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 try:
-  unicode('')
-except:
+  unicode
+except NameError:
   unicode = str
   unichr = chr
 
@@ -323,5 +323,3 @@ class ToggleController(app.controller.Controller):
     prefs = app.prefs
     prefs.save(category, name, not prefs.prefs[category][name])
     self.view.onPrefChanged(category, name)
-
-

--- a/app/fake_curses_testing.py
+++ b/app/fake_curses_testing.py
@@ -18,8 +18,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 try:
-  unicode('')
-except:
+  unicode
+except NameError:
   unicode = str
   unichr = chr
 

--- a/app/file_manager_controller.py
+++ b/app/file_manager_controller.py
@@ -16,8 +16,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 try:
-  unicode('')
-except:
+  unicode
+except NameError:
   unicode = str
   unichr = chr
 

--- a/app/history.py
+++ b/app/history.py
@@ -33,6 +33,11 @@ import time
 import app.log
 import app.prefs
 
+try:
+  unicode
+except NameError:
+  unicode = str
+
 userHistory = {}
 pathToHistory = app.prefs.prefs['userData'].get('historyPath')
 
@@ -193,4 +198,3 @@ def clearUserHistory():
     app.log.info("user history cleared")
   except Exception as e:
     app.log.error('clearUserHistory exception', e)
-

--- a/app/interactive_prompt.py
+++ b/app/interactive_prompt.py
@@ -18,8 +18,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 try:
-  unicode('')
-except:
+  unicode
+except NameError:
   unicode = str
   unichr = chr
 

--- a/app/prediction_controller.py
+++ b/app/prediction_controller.py
@@ -16,8 +16,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 try:
-  unicode('')
-except:
+  unicode
+except NameError:
   unicode = str
   unichr = chr
 

--- a/app/window.py
+++ b/app/window.py
@@ -16,8 +16,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 try:
-  type(u"") is unicode
-except:
+  unicode
+except NameError:
   unicode = str
   unichr = chr
 


### PR DESCRIPTION
This PR contains simple changes that avoid unnecessarily calling the __unicode()__ function and more importantly avoids bare exceptions as discussed in PEP8 and [other sources](https://realpython.com/the-most-diabolical-python-antipattern).